### PR TITLE
ci: run PHPUnit in CI (tests exist, were never executed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,105 @@
+name: CI — Lint & Test
+
+# Runs on every PR and every push to main.
+# Three jobs in parallel:
+#   1. PHP Lint — syntax check across supported PHP versions
+#   2. PHPCS — WordPress coding standards (non-blocking during theme rollout)
+#   3. PHPUnit — runs the theme's test suite against the WordPress test framework
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  php-lint:
+    name: PHP Lint (${{ matrix.php }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.4', '8.1', '8.3']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+      - name: Syntax check all PHP files
+        run: |
+          set -e
+          find . -name '*.php' \
+            -not -path './vendor/*' \
+            -not -path './node_modules/*' \
+            -not -path './.git/*' \
+            -print0 | xargs -0 -n1 -P4 php -l > /dev/null
+
+  phpcs:
+    name: PHPCS (WordPress standards)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: none
+          tools: composer:v2
+      - name: Install dependencies
+        run: composer install --no-progress --no-interaction --prefer-dist
+      - name: Run PHPCS
+        run: vendor/bin/phpcs --standard=.phpcs.xml.dist
+
+  phpunit:
+    name: PHPUnit (PHP ${{ matrix.php }}, WP ${{ matrix.wp }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1']
+        wp: ['latest']
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: wp_tests
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: composer:v2
+          extensions: mysqli
+      - name: Install composer dependencies
+        run: composer install --no-progress --no-interaction --prefer-dist
+      - name: Wait for MySQL
+        run: |
+          for i in {1..30}; do
+            if mysqladmin ping -h 127.0.0.1 -P 3306 -u root -proot --silent; then
+              echo "MySQL is up"; break
+            fi
+            echo "Waiting for MySQL..."; sleep 2
+          done
+      - name: Install WordPress test suite
+        env:
+          WP_TESTS_DIR: /tmp/wordpress-tests-lib
+          WP_CORE_DIR: /tmp/wordpress
+        run: |
+          chmod +x bin/install-wp-tests.sh
+          bin/install-wp-tests.sh wp_tests root root 127.0.0.1:3306 ${{ matrix.wp }}
+      - name: Run PHPUnit
+        env:
+          WP_TESTS_DIR: /tmp/wordpress-tests-lib
+        run: vendor/bin/phpunit --colors=always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,9 @@ jobs:
       - name: Install WordPress test suite
         env:
           WP_TESTS_DIR: /tmp/wordpress-tests-lib
-          WP_CORE_DIR: /tmp/wordpress
+          # Trailing slash matters: the bootstrap config substitutes this verbatim into ABSPATH,
+          # then concatenates 'wp-settings.php'. Without the slash you get '/tmp/wordpresswp-settings.php'.
+          WP_CORE_DIR: /tmp/wordpress/
         run: |
           chmod +x bin/install-wp-tests.sh
           # 6th arg = skip-database-creation: the MySQL service already created wp_tests via MYSQL_DATABASE env.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,10 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
       - uses: actions/checkout@v4
+      - name: Install subversion
+        # ubuntu-latest no longer ships svn preinstalled. The WP test suite
+        # bootstrap script checks out develop.svn.wordpress.org via svn.
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends subversion
       - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,8 @@ jobs:
           WP_CORE_DIR: /tmp/wordpress
         run: |
           chmod +x bin/install-wp-tests.sh
-          bin/install-wp-tests.sh wp_tests root root 127.0.0.1:3306 ${{ matrix.wp }}
+          # 6th arg = skip-database-creation: the MySQL service already created wp_tests via MYSQL_DATABASE env.
+          bin/install-wp-tests.sh wp_tests root root 127.0.0.1:3306 ${{ matrix.wp }} true
       - name: Run PHPUnit
         env:
           WP_TESTS_DIR: /tmp/wordpress-tests-lib

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Install WordPress core + test suite for running PHPUnit locally or in CI.
+#
+# Usage: install-wp-tests.sh <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]
+#
+# Sourced from the standard WP-CLI scaffold script, lightly hardened:
+#   - set -euo pipefail
+#   - quieter curl
+#   - supports WP_TESTS_DIR / WP_CORE_DIR overrides via env
+#
+# Why vendored: the script is stable, changes rarely, and vendoring avoids a
+# curl-from-github step in CI. Kept here so the CI workflow is reproducible.
+
+set -euo pipefail
+
+if [ $# -lt 3 ]; then
+    echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+    exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
+
+TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo "$TMPDIR" | sed -e "s/\/$//")
+WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
+
+download() {
+    if [ "$(which curl)" ]; then
+        curl -s "$1" > "$2"
+    elif [ "$(which wget)" ]; then
+        wget -nv -O "$2" "$1"
+    else
+        echo "Neither curl nor wget found." >&2
+        exit 1
+    fi
+}
+
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
+    WP_BRANCH=${WP_VERSION%\-*}
+    WP_TESTS_TAG="branches/$WP_BRANCH"
+elif [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+    WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+        WP_TESTS_TAG="tags/${WP_VERSION%??}"
+    else
+        WP_TESTS_TAG="tags/$WP_VERSION"
+    fi
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+    WP_TESTS_TAG="trunk"
+else
+    # Latest — resolve via the WordPress.org version-check API.
+    download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+    LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//' | head -1)
+    if [[ -z "$LATEST_VERSION" ]]; then
+        echo "Could not resolve latest WordPress version." >&2
+        exit 1
+    fi
+    WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+
+install_wp() {
+    if [ -d "$WP_CORE_DIR" ]; then
+        return
+    fi
+    mkdir -p "$WP_CORE_DIR"
+
+    if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+        mkdir -p "$TMPDIR/wordpress-nightly"
+        download https://wordpress.org/nightly-builds/wordpress-latest.zip "$TMPDIR/wordpress-nightly/wordpress-nightly.zip"
+        unzip -q "$TMPDIR/wordpress-nightly/wordpress-nightly.zip" -d "$TMPDIR/wordpress-nightly/"
+        mv "$TMPDIR/wordpress-nightly/wordpress/"* "$WP_CORE_DIR"
+    else
+        if [ "$WP_VERSION" == 'latest' ]; then
+            local ARCHIVE_NAME='latest'
+        elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+            download https://api.wordpress.org/core/version-check/1.7/ "$TMPDIR/wp-latest.json"
+            if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+                LATEST_VERSION=${WP_VERSION%??}
+            else
+                local VERSION_ESCAPED=${WP_VERSION//./\\\\.}
+                LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' "$TMPDIR/wp-latest.json" | sed 's/"version":"//' | head -1)
+            fi
+            if [[ -z "$LATEST_VERSION" ]]; then
+                local ARCHIVE_NAME="wordpress-$WP_VERSION"
+            else
+                local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+            fi
+        else
+            local ARCHIVE_NAME="wordpress-$WP_VERSION"
+        fi
+        download https://wordpress.org/${ARCHIVE_NAME}.tar.gz "$TMPDIR/wordpress.tar.gz"
+        tar --strip-components=1 -zxmf "$TMPDIR/wordpress.tar.gz" -C "$WP_CORE_DIR"
+    fi
+
+    download https://raw.githubusercontent.com/markoheijnen/wp-mysqli/master/db.php "$WP_CORE_DIR/wp-content/db.php"
+}
+
+install_test_suite() {
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        local ioption='-i.bak'
+    else
+        local ioption='-i'
+    fi
+
+    if [ ! -d "$WP_TESTS_DIR" ]; then
+        mkdir -p "$WP_TESTS_DIR"
+        svn co --quiet "https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/" "$WP_TESTS_DIR/includes"
+        svn co --quiet "https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/" "$WP_TESTS_DIR/data"
+    fi
+
+    if [ ! -f wp-tests-config.php ]; then
+        download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR/wp-tests-config.php"
+        WP_CORE_DIR_ESCAPED=${WP_CORE_DIR//\//\\/}
+        sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR_ESCAPED':" "$WP_TESTS_DIR/wp-tests-config.php"
+        sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR/wp-tests-config.php"
+        sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR/wp-tests-config.php"
+        sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR/wp-tests-config.php"
+        sed $ioption "s|localhost|$DB_HOST|" "$WP_TESTS_DIR/wp-tests-config.php"
+    fi
+}
+
+install_db() {
+    if [ "${SKIP_DB_CREATE}" = "true" ]; then
+        return 0
+    fi
+
+    local PARTS=(${DB_HOST//\:/ })
+    local DB_HOSTNAME=${PARTS[0]}
+    local DB_SOCK_OR_PORT=${PARTS[1]-}
+    local EXTRA=""
+    if [ -n "$DB_HOSTNAME" ]; then
+        if [ "$DB_SOCK_OR_PORT" != "" ] && [ $(echo "$DB_SOCK_OR_PORT" | grep -E '^[0-9]+$') ]; then
+            EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+        elif [ "$DB_SOCK_OR_PORT" != "" ] && [ -e "$DB_SOCK_OR_PORT" ]; then
+            EXTRA=" --socket=$DB_SOCK_OR_PORT"
+        else
+            EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+        fi
+    fi
+    mysqladmin create "$DB_NAME" --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db
+
+echo "WordPress test suite installed at $WP_TESTS_DIR"


### PR DESCRIPTION
**What changed**

Adds `.github/workflows/ci.yml` that runs three jobs on every PR and every push to main: PHP Lint (7.4, 8.1, 8.3), PHPCS (non-blocking), and PHPUnit against the WordPress test framework on a MySQL 8 service. Also vendors `bin/install-wp-tests.sh` (standard WP-CLI scaffold script) so CI is reproducible without a curl-from-github step.

**Why**

PR Theme already has 59 tests across 8 files covering auth, rate limiting, email verification, newsletter, contact handler, functions, and theme setup — but none of them were running in CI. The audit flagged test coverage as the weakest area of the codebase; turns out the tests are there, they just never execute. This closes the gap.

**Risk flags**

- First PHPUnit-on-WP run on this repo. Tests may fail if they assumed local WP state that the CI test framework does not provide. If so, the failures are informative and will guide follow-up fixes.
- `continue-on-error: true` on PHPCS keeps it non-blocking during rollout so a style nit does not block a real test fix.
- No change to deploy.yml — deploy still fires only on push to main, as before.

**Test plan after merge**

1. This PR itself exercises the new workflow. The first run of `CI — Lint & Test` on this PR shows whether all 59 tests pass.
2. If any tests fail, open a follow-up PR to fix them (likely minor WP-test-suite isolation tweaks).
3. Confirm the CTO reviewer (from the just-merged review gate) posts an APPROVE / REQUEST_CHANGES on this PR — first real test of that pipeline too.

Agent-Session: cowork-pr-theme-tests-20260414