### PR TITLE
ci: fix CTO reviewer + harden deploy ssh-keyscan

### DIFF
--- a/.github/workflows/cto-review.yml
+++ b/.github/workflows/cto-review.yml
@@ -224,25 +224,22 @@ jobs:
           PY
 
       - name: Post PR review
+        # Always posts as COMMENT — not APPROVE/REQUEST_CHANGES — because the default
+        # GITHUB_TOKEN is not permitted to formally approve PRs without toggling a
+        # repo setting. The verdict is still prominent in the first line of the body
+        # ("## CTO Review — APPROVE|REQUEST_CHANGES|COMMENT"). Human merges, so the
+        # GitHub-native review state isn't load-bearing.
         if: steps.claude.outputs.skipped != '1'
         uses: actions/github-script@v7
-        env:
-          VERDICT: ${{ steps.claude.outputs.verdict }}
         with:
           script: |
             const fs = require('fs');
             const body = fs.readFileSync('/tmp/review-body.md', 'utf8');
-            const verdict = process.env.VERDICT;
-            const eventMap = {
-              'APPROVE': 'APPROVE',
-              'REQUEST_CHANGES': 'REQUEST_CHANGES',
-              'COMMENT': 'COMMENT'
-            };
             await github.rest.pulls.createReview({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number,
-              event: eventMap[verdict] || 'COMMENT',
+              event: 'COMMENT',
               body,
             });
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,12 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+          # Best-effort: keyscan stderr captured for diagnosis but never fatal.
+          # We use StrictHostKeyChecking=no on the actual ssh/rsync calls anyway.
+          ssh-keyscan -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts 2>/tmp/keyscan.err || {
+            echo "::warning::ssh-keyscan failed (non-fatal). stderr:"
+            cat /tmp/keyscan.err || true
+          }
 
       - name: Deploy via rsync
         run: |


### PR DESCRIPTION
**What changed**

Two related CI fixes on the theme repo:

1. **CTO reviewer posts as COMMENT** — `pulls.createReview` with event `APPROVE` was failing because GITHUB_TOKEN cannot formally approve PRs without a repo setting toggle. Verdict stays in the body heading; behavior preserved.
2. **Deploy ssh-keyscan is now best-effort** — the keyscan was running under `set -e` with stderr suppressed, so any keyscan failure killed the whole deploy with no diagnostic output. Since rsync/ssh use `StrictHostKeyChecking=no`, known_hosts is not load-bearing. The keyscan now logs a warning on failure and continues. This is what caused the deploy failure on the v1.5.2 review-gate merge.

**Why**

Both issues were uncovered by the first real run of the new infrastructure. Fixing them now closes the loop end-to-end.

**Risk flags**

- The deploy fix means a misconfigured SSH_HOST/SSH_PORT secret will no longer be caught at the keyscan step — it will fail later at the rsync step instead. That is fine (and arguably better, since the rsync error is more informative than a silent keyscan exit code).
- The reviewer change loses the GitHub-native APPROVE checkmark UI. Verdict is still legible in the comment.

**Test plan**

- Merge this PR.
- Re-run the CTO Review workflow on PR #2 — should post a COMMENT successfully.
- Next push to main triggers a deploy, which should succeed (or fail informatively at the rsync step if SSH config is genuinely broken).

Agent-Session: cowork-reviewer-fix-20260414, cowork-deploy-fix-20260414