### PR TITLE
ci(deploy): tolerate 403 on post-deploy health check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,8 +88,13 @@ jobs:
         run: |
           sleep 5
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://peptiderepo.com)
-          if [ "$STATUS" != "200" ]; then
-            echo "WARNING: Site returned HTTP $STATUS after deploy"
+          # 200 = normal healthy response.
+          # 403 = peptide-starter-theme v1.5.2 CF-peer validator rejecting this
+          #       GHA-runner direct-to-origin request as non-Cloudflare traffic.
+          #       That rejection is the validator working — itself a positive
+          #       liveness signal. Real user traffic via Cloudflare gets 200.
+          if [ "$STATUS" != "200" ] && [ "$STATUS" != "403" ]; then
+            echo "ERROR: Site returned unexpected HTTP $STATUS after deploy"
             exit 1
           fi
-          echo "Site is healthy (HTTP 200)"
+          echo "Site is responsive (HTTP $STATUS)"


### PR DESCRIPTION
## Summary

Two deploys today (peptide-starter-theme v1.5.2, prautoblogger Commit 1a) both shipped clean but reported workflow `failure` because the post-deploy health-check curl returned 403 — the new `peptide_starter_is_cloudflare_peer()` validator from v1.5.2 correctly rejects direct-to-origin requests from non-Cloudflare IPs (i.e. GHA runners). Real user traffic via Cloudflare gets 200 as expected.

## What / Why / Risk / Test-plan

- **What:** post-deploy health check now accepts 200 or 403, fails only on other status codes (5xx, other 4xx, connection failure).
- **Why:** the v1.5.2 validator returning 403 to our own check is itself a positive liveness signal — the validator is alive. Real user traffic via CF still gets 200. Same fix applied across all three repos with health checks (PRAutoblogger, PR Theme, Peptide Search AI). Peptide News deploy.yml has no health check, so untouched.
- **Risk:** very low. We lose the ability to distinguish "site truly down with a 403 status page" from "CF-validator rejecting GHA runner" — but a real 5xx/connection-fail still triggers workflow failure, and prod monitoring catches user-facing 403s separately.
- **Test-plan:** verified locally via `python3 -c 'import yaml; yaml.safe_load(...)'` on each patched workflow. Live validation is the next deploy after merge — should report green on a successful rsync where currently it reports failure.