### PR TITLE
refactor: remove WooCommerce integration (v1.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the Peptide Starter Theme are documented in this file.
 
+## [1.7.0] - 2026-04-24 — Remove WooCommerce integration
+
+WooCommerce is not used on peptiderepo.com. Removing dead code reduces the asset
+dequeue surface and eliminates the function_exists() guard introduced in the 2026-04-23
+hotfix.
+
+### Removed
+- WooCommerce asset dequeue block from `inc/perf-asset-policy.php` (styles:
+  woocommerce-layout, woocommerce-smallscreen, woocommerce-general; scripts:
+  wc-add-to-cart, woocommerce, sourcebuster-js, wc-order-attribution)
+- Cart icon in `header.php` (was conditional on `class_exists('WooCommerce')`)
+- `peptide_starter_perf_woocommerce_styles` and `peptide_starter_perf_woocommerce_scripts`
+  filter hooks
+- WooCommerce-specific tests from `tests/test-perf-asset-policy.php`
+- WooCommerce section from README.md and CONVENTIONS.md
+
 ## [1.6.0] - 2026-04-23 — Mobile Performance Phase 1
 
 Mobile-perf optimization targeting LCP reduction through conditional asset

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -460,11 +460,6 @@ if ( is_active_sidebar( 'footer-1' ) ) {
 
 ### Class Existence Check
 
-**For WooCommerce:**
-```php
-if ( class_exists( 'WooCommerce' ) ) {
-  // Render cart icon
-}
 ```
 
 **For post types:**

--- a/header.php
+++ b/header.php
@@ -115,15 +115,6 @@
 				</svg>
 			</button>
 
-			<!-- Cart Icon (WooCommerce) -->
-			<?php if ( class_exists( 'WooCommerce' ) ) { ?>
-				<button class="header-icon-btn cart-toggle" aria-label="<?php esc_attr_e( 'View cart', 'peptide-starter' ); ?>">
-					<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-						<path d="M1 1H3.27924M3.27924 1L5.20081 13.5631C5.35072 14.4571 5.80765 15.2614 6.4543 15.8285C7.10095 16.3956 7.92274 16.6882 8.76721 16.6882H16.7257M16.7257 16.6882C17.3169 16.6882 17.7793 17.1506 17.7793 17.7418C17.7793 18.333 17.3169 18.7955 16.7257 18.7955M16.7257 16.6882C15.6515 16.6882 14.4632 16.6882 8.76721 16.6882M8.76721 16.6882C8.17601 16.6882 7.71365 17.1506 7.71365 17.7418C7.71365 18.333 8.17601 18.7955 8.76721 18.7955M5.20081 13.5631H16.7257" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-					</svg>
-				</button>
-			<?php } ?>
-
 			<!-- Mobile Menu Toggle -->
 			<button class="menu-toggle" aria-label="<?php esc_attr_e( 'Toggle menu', 'peptide-starter' ); ?>">
 				<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/inc/perf-asset-policy.php
+++ b/inc/perf-asset-policy.php
@@ -4,7 +4,7 @@
  *
  * Optimizes the front-end asset graph by dequeuing unnecessary plugin styles/scripts
  * and slimming font requests. Targets mobile LCP improvement through:
- * - Conditional dequeue of WC, Elementor, and USMI assets
+ * - Conditional dequeue of Elementor and USMI assets
  * - Google Fonts weight slimming (36 faces → 5)
  * - Preconnect hints for font.googleapis.com + fonts.gstatic.com
  * - Defer attribute on cookie-notice script
@@ -49,11 +49,10 @@ function peptide_starter_perf_asset_policy_init() {
 /**
  * Dequeue assets on non-applicable page types.
  *
- * Removes WooCommerce, Elementor, and Ultimate Social Media Icons assets from pages
+ * Removes Elementor and Ultimate Social Media Icons assets from pages
  * that don't use them. Controlled by the kill-switch constant PEPTIDE_STARTER_PERF_DEQUEUE.
  *
  * Dequeue conditions:
- * - WC: removed unless on shop, cart, checkout, or account pages
  * - Elementor: removed if page doesn't use Elementor builder
  * - USMI: removed on homepage, archives, and blog index
  *
@@ -63,28 +62,6 @@ function peptide_starter_perf_dequeue_plugin_assets() {
 	// Kill-switch: if disabled in wp-config.php, do nothing.
 	if ( defined( 'PEPTIDE_STARTER_PERF_DEQUEUE' ) && ! PEPTIDE_STARTER_PERF_DEQUEUE ) {
 		return;
-	}
-
-	// WooCommerce assets: dequeue on non-shop pages.
-	if ( function_exists( 'is_woocommerce' ) && ! is_woocommerce() && ! is_cart() && ! is_checkout() && ! is_account_page() ) {
-		// Get configured WC handles from filter; default list.
-		$wc_styles = apply_filters(
-			'peptide_starter_perf_woocommerce_styles',
-			array( 'woocommerce-layout', 'woocommerce-smallscreen', 'woocommerce-general' )
-		);
-
-		foreach ( $wc_styles as $handle ) {
-			wp_dequeue_style( $handle );
-		}
-
-		$wc_scripts = apply_filters(
-			'peptide_starter_perf_woocommerce_scripts',
-			array( 'wc-add-to-cart', 'woocommerce', 'sourcebuster-js', 'wc-order-attribution' )
-		);
-
-		foreach ( $wc_scripts as $handle ) {
-			wp_dequeue_script( $handle );
-		}
 	}
 
 	// Elementor assets: dequeue if page doesn't use Elementor.

--- a/tests/test-perf-asset-policy.php
+++ b/tests/test-perf-asset-policy.php
@@ -2,7 +2,7 @@
 /**
  * Tests for inc/perf-asset-policy.php.
  *
- * Covers: conditional dequeue logic (WC, Elementor, USMI), font weight slimming,
+ * Covers: conditional dequeue logic (Elementor, USMI), font weight slimming,
  * preconnect hints, script defer, kill-switch, and filter overrides.
  *
  * @package peptide-starter
@@ -24,57 +24,16 @@ class Test_Perf_Asset_Policy extends WP_UnitTestCase {
 		define( 'PEPTIDE_STARTER_PERF_DEQUEUE', false );
 
 		// Enqueue dummy styles.
-		wp_enqueue_style( 'woocommerce-layout', 'http://example.com/wc.css' );
+		wp_enqueue_style( 'elementor-frontend', 'http://example.com/elementor.css' );
 
 		// Simulate wp_enqueue_scripts action.
 		do_action( 'wp_enqueue_scripts' );
 
 		// Since kill-switch is off, the style should still be queued.
-		$this->assertTrue( wp_style_is( 'woocommerce-layout', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'elementor-frontend', 'enqueued' ) );
 	}
 
-	/**
-	 * Test: WC assets dequeued on non-shop pages.
-	 *
-	 * Homepage (front page) is not a WC page, so WC styles/scripts should dequeue.
-	 */
-	public function test_wc_dequeue_on_homepage() {
-		$this->go_to( home_url( '/' ) );
 
-		// Enqueue WC styles.
-		wp_enqueue_style( 'woocommerce-layout', 'http://example.com/wc-layout.css' );
-		wp_enqueue_style( 'woocommerce-general', 'http://example.com/wc-general.css' );
-		wp_enqueue_script( 'woocommerce', 'http://example.com/wc.js' );
-
-		// Run dequeue at priority 100.
-		peptide_starter_perf_dequeue_plugin_assets();
-
-		// All WC assets should be dequeued.
-		$this->assertFalse( wp_style_is( 'woocommerce-layout', 'enqueued' ) );
-		$this->assertFalse( wp_style_is( 'woocommerce-general', 'enqueued' ) );
-		$this->assertFalse( wp_script_is( 'woocommerce', 'enqueued' ) );
-	}
-
-	/**
-	 * Test: WC assets remain on /shop page.
-	 *
-	 * On WC shop pages, WC assets should NOT dequeue.
-	 */
-	public function test_wc_not_dequeued_on_shop() {
-		// Skip if WooCommerce is not active.
-		if ( ! class_exists( 'WooCommerce' ) ) {
-			$this->markTestSkipped( 'WooCommerce not active.' );
-		}
-
-		// Enqueue WC styles.
-		wp_enqueue_style( 'woocommerce-layout', 'http://example.com/wc-layout.css' );
-
-		// The dequeue function checks is_woocommerce(); we'll mock it.
-		// For a true test, we'd need a real WC shop page setup.
-		// Instead, we assert the filter allows override.
-		$default_handles = apply_filters( 'peptide_starter_perf_woocommerce_styles', array() );
-		$this->assertIsArray( $default_handles );
-	}
 
 	/**
 	 * Test: Elementor assets dequeued on pages without Elementor.


### PR DESCRIPTION
WooCommerce is not installed or used on peptiderepo.com. Removes all dead code:

- `inc/perf-asset-policy.php` — WC asset dequeue block + filter hooks
- `header.php` — Cart icon conditional
- `tests/test-perf-asset-policy.php` — WC-specific tests; kill-switch test updated to use non-WC handle
- `README.md`, `CONVENTIONS.md`, `CHANGELOG.md` — docs updated

Version: 1.6.0 → 1.7.0