### PR TITLE
feat(front-page): remove Science Feed card + 3-item news teaser (v2.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Peptide Starter Theme - Changelog
 
+## [2.2.2] - 2026-04-29 — Front page layout restructure
+
+### Changed
+
+- `template-parts/module-cards.php`: Removed Science Feed from the module card
+  grid. The grid is for interactive tools only; news is content. Grid is now
+  5 cards: Peptides, Calculator, Protocol Builder, Tracker, Subject Log. No card
+  in this set goes inactive-dimmed due to a plugin registration check.
+- `front-page.php`: Replaced the full `[peptide_news]` inline feed with a
+  3-item teaser row (`[peptide_news count="3"]`) and a "View all research →"
+  CTA linking to `/news`. Reduces page weight and drives traffic to the
+  dedicated news page.
+
 ## [2.2.1] - 2026-04-29 — RCT inline abbreviation tooltip
 
 ### Added

--- a/front-page.php
+++ b/front-page.php
@@ -204,7 +204,7 @@ $featured_monograph_ids = array( 211, 36, 177 );
 	</section>
 	<?php endif; ?>
 
-	<!-- Research Modules Grid (6 cards) -->
+	<!-- Research Modules Grid (5 cards) -->
 	<?php get_template_part( 'template-parts/module', 'cards' ); ?>
 
 	<!-- PRAutoBlogger Posts Widget -->
@@ -214,19 +214,22 @@ $featured_monograph_ids = array( 211, 36, 177 );
 	}
 	?>
 
-	<!-- News Feed Section -->
+	<!-- News Teaser Section — 3 items + "View all" CTA -->
 	<?php
 	if ( shortcode_exists( 'peptide_news' ) ) {
 		?>
-		<section class="news-feed-section">
+		<section class="news-teaser-section">
 			<div class="ps-container">
-				<div class="news-feed-header">
-					<h2 class="news-feed-title"><?php esc_html_e( 'What\'s new', 'peptide-starter' ); ?></h2>
-					<p class="news-feed-description">
-						<?php esc_html_e( 'Recent peptide research, regulatory shifts, and synthesis news. New posts weekly.', 'peptide-starter' ); ?>
-					</p>
+				<div class="news-teaser-header">
+					<div>
+						<h2><?php esc_html_e( 'Latest Peptide Research', 'peptide-starter' ); ?></h2>
+						<p><?php esc_html_e( 'Recent publications from leading research sources.', 'peptide-starter' ); ?></p>
+					</div>
+					<a href="<?php echo esc_url( home_url( '/news' ) ); ?>" class="ps-btn ps-btn-secondary">
+						<?php esc_html_e( 'View all research →', 'peptide-starter' ); ?>
+					</a>
 				</div>
-				<?php echo do_shortcode( '[peptide_news]' ); ?>
+				<?php echo do_shortcode( '[peptide_news count="3"]' ); ?>
 			</div>
 		</section>
 		<?php
@@ -236,3 +239,4 @@ $featured_monograph_ids = array( 211, 36, 177 );
 </main>
 
 <?php get_footer(); ?>
+

--- a/functions.php
+++ b/functions.php
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Theme constants.
-define( 'PEPTIDE_STARTER_VERSION', '2.2.1' );
+define( 'PEPTIDE_STARTER_VERSION', '2.2.2' );
 define( 'PEPTIDE_STARTER_DIR', get_template_directory() );
 define( 'PEPTIDE_STARTER_URI', get_template_directory_uri() );
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/peptiderepo/peptide-starter
 Description: Premium, accessible WordPress theme for scientific peptide reference database
 Author: Peptide Repo
 Author URI: https://peptiderepo.com
-Version: 2.2.1
+Version: 2.2.2
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: peptide-starter

--- a/template-parts/module-cards.php
+++ b/template-parts/module-cards.php
@@ -2,7 +2,7 @@
 /**
  * Template Part: Research Module Cards
  *
- * Renders a 6-card grid of research modules (tools/sections) for the front page.
+ * Renders a 5-card grid of research modules (tools/sections) for the front page.
  * Each card checks if the target plugin is active; inactive cards are dimmed.
  * Cards with 'coming_soon' => true display a "Coming soon" badge overlaid in
  * the top-right corner — layered on top of the --inactive visual treatment.
@@ -59,14 +59,6 @@ $modules = array(
 		'coming_soon' => true,
 	),
 	array(
-		'title'       => __( 'Science Feed', 'peptide-starter' ),
-		'description' => __( 'What\'s new in peptide research. Filtered for what matters, weekly.', 'peptide-starter' ),
-		'url'         => '/news',
-		'icon'        => '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 22h16a2 2 0 002-2V4a2 2 0 00-2-2H8a2 2 0 00-2 2v16a2 2 0 01-2 2zm0 0a2 2 0 01-2-2v-9c0-1.1.9-2 2-2h2"/><line x1="10" y1="6" x2="18" y2="6"/><line x1="10" y1="10" x2="18" y2="10"/><line x1="10" y1="14" x2="14" y2="14"/></svg>',
-		'available'   => shortcode_exists( 'peptide_news' ),
-		'coming_soon' => false,
-	),
-	array(
 		'title'       => __( 'Subject Log', 'peptide-starter' ),
 		'description' => __( 'Track outcomes over time. Subjective markers, lab results, protocol changes — your own data, kept private.', 'peptide-starter' ),
 		'url'         => '/subject-log',
@@ -109,3 +101,4 @@ $modules = array(
 		</div>
 	</div>
 </section>
+


### PR DESCRIPTION
## Summary

Two front-page layout changes per CMO brief (2026-04-29).

### Change 1 — Remove Science Feed from module card grid

**File:** `template-parts/module-cards.php`

Deleted the Science Feed array entry. Grid is now 5 cards: **Peptides · Calculator · Protocol Builder · Tracker · Subject Log.**

**Why:** The module grid is for interactive tools. Science Feed is content, not a tool. The `available` check tied to `shortcode_exists('peptide_news')` was dimming the card whenever the plugin wasn't registered — making a live page (`/news`) appear as "coming soon." Removing the card eliminates the false-inactive signal cleanly. News discovery is handled by Change 2.

### Change 2 — Replace inline news feed with 3-item teaser

**File:** `front-page.php`

Replaced the full `[peptide_news]` inline feed with `[peptide_news count="3"]` in a teaser layout. Adds a "View all research →" CTA linking to `/news`.

**Why:** The full feed on the front page is heavy and redundant. A 3-item teaser signals the feed is alive without loading everything; the CTA drives traffic to the dedicated page.

Note: `[peptide_news]` already supports the `count` attribute natively (`shortcode_atts` default = admin setting, overridable per-call). No plugin changes needed.

---

**Version:** 2.2.1 → 2.2.2 (patch)

## Files changed

- `template-parts/module-cards.php` — Science Feed entry removed, docblock updated (6→5 cards)
- `front-page.php` — news-feed-section replaced with news-teaser-section
- `style.css` — version bump 2.2.1 → 2.2.2
- `CHANGELOG.md` — 2.2.2 entry added

## Test checklist

- [ ] Front page renders without PHP errors
- [ ] Module grid shows exactly 5 cards (no Science Feed)
- [ ] No card shows dimmed/inactive state unexpectedly
- [ ] News teaser section shows 3 items
- [ ] "View all research →" links to `/news`
- [ ] `/news` page is unaffected
