### PR TITLE
ci: adopt estate CI standard (peptide-starter-theme v2.3.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,112 +1,24 @@
-name: CI — Lint & Test
+name: CI
 
-# Runs on every PR and every push to main.
-# Three jobs in parallel:
-#   1. PHP Lint — syntax check across supported PHP versions
-#   2. PHPCS — WordPress coding standards (non-blocking during theme rollout)
-#   3. PHPUnit — runs the theme's test suite against the WordPress test framework
-
+# Thin caller — delegates all jobs to the shared reusable workflow.
+# Must include workflow_call so deploy.yml can gate on this workflow.
 on:
+  pull_request: {}
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_call: {}
 
+# Required by the reusable phpcs job which commits phpcbf auto-fixes back
+# to the PR branch. GitHub enforces that callers declare at least the same
+# permissions as any job-level override in the called workflow.
 permissions:
-  contents: read
+  contents: write
 
 jobs:
-  php-lint:
-    name: PHP Lint (${{ matrix.php }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php: ['8.1', '8.2', '8.3']
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          coverage: none
-      - name: Syntax check all PHP files
-        run: |
-          set -e
-          find . -name '*.php' \
-            -not -path './vendor/*' \
-            -not -path './node_modules/*' \
-            -not -path './.git/*' \
-            -print0 | xargs -0 -n1 -P4 php -l > /dev/null
-
-  phpcs:
-    name: PHPCS (WordPress standards)
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.1'
-          coverage: none
-          tools: composer:v2
-      - name: Install dependencies
-        run: composer install --no-progress --no-interaction --prefer-dist
-      - name: Run PHPCS
-        run: vendor/bin/phpcs --standard=.phpcs.xml.dist
-
-  phpunit:
-    name: PHPUnit (PHP ${{ matrix.php }}, WP ${{ matrix.wp }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php: ['8.1', '8.2', '8.3']
-        wp: ['latest']
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: wp_tests
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install subversion
-        # ubuntu-latest no longer ships svn preinstalled. The WP test suite
-        # bootstrap script checks out develop.svn.wordpress.org via svn.
-        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends subversion
-      - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          coverage: none
-          tools: composer:v2
-          extensions: mysqli
-      - name: Install composer dependencies
-        run: composer install --no-progress --no-interaction --prefer-dist
-      - name: Wait for MySQL
-        run: |
-          for i in {1..30}; do
-            if mysqladmin ping -h 127.0.0.1 -P 3306 -u root -proot --silent; then
-              echo "MySQL is up"; break
-            fi
-            echo "Waiting for MySQL..."; sleep 2
-          done
-      - name: Install WordPress test suite
-        env:
-          WP_TESTS_DIR: /tmp/wordpress-tests-lib
-          # Trailing slash matters: the bootstrap config substitutes this verbatim into ABSPATH,
-          # then concatenates 'wp-settings.php'. Without the slash you get '/tmp/wordpresswp-settings.php'.
-          WP_CORE_DIR: /tmp/wordpress/
-        run: |
-          chmod +x bin/install-wp-tests.sh
-          # 6th arg = skip-database-creation: the MySQL service already created wp_tests via MYSQL_DATABASE env.
-          bin/install-wp-tests.sh wp_tests root root 127.0.0.1:3306 ${{ matrix.wp }} true
-      - name: Run PHPUnit
-        env:
-          WP_TESTS_DIR: /tmp/wordpress-tests-lib
-        run: vendor/bin/phpunit --colors=always
+  ci:
+    uses: peptiderepo/peptide-e2e/.github/workflows/ci.yml@main
+    with:
+      tests: wp-framework
+      has_js: true
+      line_limit_paths: inc
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,30 +9,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
-    name: Validate PHP & JS
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: PHP Lint Check
-        run: |
-          find . -name "*.php" -not -path "./vendor/*" -not -path "./node_modules/*" -exec php -l {} \; | (grep -v "No syntax errors" || true) | head -20
-          test ${PIPESTATUS[0]} -eq 0
-      - name: Install PHPCS with WordPress standards
-        run: |
-          composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-          composer global require --dev squizlabs/php_codesniffer:"^3.0" wp-coding-standards/wpcs:"^3.0" phpcsstandards/phpcsutils:"^1.0"
-      - name: Run PHPCS (WordPress Core)
-        run: |
-          ~/.composer/vendor/bin/phpcs -s . || true  # non-blocking during theme rollout
-      - name: JS Syntax Check
-        run: |
-          find assets/js -name "*.js" -exec node --check {} \;
+  # Gate deploy on the reusable CI (lint-php, phpcs, phpunit, file-size, lint-js).
+  # ci.yml exposes workflow_call so it can be used here without re-running a
+  # separate workflow — the call result satisfies the branch-protection context
+  # "ci / ci (lint-php (8.1))" etc.
+  ci:
+    uses: ./.github/workflows/ci.yml
 
   deploy:
     name: Deploy (shared pipeline)
-    needs: validate
+    needs: ci
     uses: peptiderepo/peptide-e2e/.github/workflows/deploy-app.yml@main
     with:
       target_path: wp-content/themes/peptide-starter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Peptide Starter Theme - Changelog
 
+## [2.3.0] - 2026-06-16 — Adopt estate CI standard
+
+### Changed
+
+- `.github/workflows/ci.yml`: Replaced per-repo CI jobs with a thin caller
+  delegating to `peptiderepo/peptide-e2e/.github/workflows/ci.yml@main`
+  (`tests: wp-framework`, `has_js: true`, `line_limit_paths: inc`). Added
+  `workflow_call` trigger so `deploy.yml` can gate on this workflow.
+- `.github/workflows/deploy.yml`: Retired standalone `validate` job; deploy
+  now gates on the reusable CI via `uses: ./.github/workflows/ci.yml`.
+- `composer.json`: `test` script now calls `vendor/bin/phpunit` explicitly
+  (was bare `phpunit`).
+- `inc/helpers.php`: Split 311-line file at the nav-walker boundary; reduced
+  to 211 lines.
+
+### Added
+
+- `inc/nav-walker.php`: `Peptide_Starter_Nav_Walker` class and
+  `peptide_starter_primary_menu_fallback()` extracted from `inc/helpers.php`
+  (123 lines). Loaded in `functions.php` before `helpers.php`.
+- `package.json` / `package-lock.json`: Minimal npm manifest so the reusable
+  `lint-js` job can run `npm ci` and then execute `npm run lint` (which runs
+  `node --check` on `assets/js/**/*.js`).
+
+
 ## [2.2.2] - 2026-04-29 — Front page layout restructure
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	"scripts": {
 		"lint": "phpcs",
 		"lint:fix": "phpcbf",
-		"test": "phpunit"
+		"test": "vendor/bin/phpunit"
 	},
 	"config": {
 		"allow-plugins": {

--- a/functions.php
+++ b/functions.php
@@ -7,6 +7,8 @@
  * 300 lines and to make responsibilities discoverable.
  *
  * @see inc/config.php           — security configuration
+ * @see inc/nav-walker.php       — Peptide_Starter_Nav_Walker + primary menu fallback
+ * @see inc/helpers.php          — customizer helpers, gates, honeypot, CSV utility
  * @see inc/rate-limiter.php     — transient-backed rate limiter
  * @see inc/email-verification.php — token-gated email verification
  * @see inc/auth-handlers.php    — AJAX login + registration
@@ -14,7 +16,6 @@
  * @see inc/newsletter-admin.php — admin subscriber viewer + unsubscribe
  * @see inc/page-setup.php       — auto-create pages + v1.5.0 user migration
  * @see inc/mail-diagnostic.php  — admin deliverability test tool
- * @see inc/helpers.php          — nav walker, menu fallback, gates, utilities
  * @see inc/perf-asset-policy.php — asset dequeue + font slim + preconnect + defer
  *
  * @package peptide-starter
@@ -26,13 +27,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Theme constants.
-define( 'PEPTIDE_STARTER_VERSION', '2.2.2' );
+define( 'PEPTIDE_STARTER_VERSION', '2.3.0' );
 define( 'PEPTIDE_STARTER_DIR', get_template_directory() );
 define( 'PEPTIDE_STARTER_URI', get_template_directory_uri() );
 
 // Load feature modules. Order matters — config must load before anything
 // that calls peptide_starter_config_*; rate limiter before handlers.
 require_once PEPTIDE_STARTER_DIR . '/inc/config.php';
+require_once PEPTIDE_STARTER_DIR . '/inc/nav-walker.php';
 require_once PEPTIDE_STARTER_DIR . '/inc/helpers.php';
 require_once PEPTIDE_STARTER_DIR . '/inc/cloudflare-ips.php';
 require_once PEPTIDE_STARTER_DIR . '/inc/rate-limiter.php';

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -2,17 +2,21 @@
 /**
  * Theme Helper Functions
  *
- * Customizer output helpers, nav walker, custom logo, pagination, menu
- * fallback, auth gates, and assorted utilities shared across the theme.
+ * Customizer output helpers, custom logo, pagination, auth gates,
+ * honeypot, and CSV utility shared across the theme.
  *
- * @see functions.php — includes this file
- * @see header.php — uses peptide_starter_the_custom_logo() + menu fallback
+ * Navigation walker and primary menu fallback have been extracted to
+ * inc/nav-walker.php (v2.3.0) to keep this file under 300 lines.
+ *
+ * @see functions.php        — includes this file (after nav-walker.php)
+ * @see inc/nav-walker.php   — Peptide_Starter_Nav_Walker + menu fallback
+ * @see header.php           — uses peptide_starter_the_custom_logo()
  * @see page-subject-log.php, page-tracker.php, page-protocol-builder.php —
  *   use peptide_starter_require_login()
  *
  * What: Utility functions for template output, theme mods, auth gating.
  * Who calls it: Templates and handler files.
- * Dependencies: WordPress Customizer API, Walker_Nav_Menu, email-verification.
+ * Dependencies: WordPress Customizer API, email-verification.
  *
  * @package peptide-starter
  */
@@ -20,110 +24,6 @@
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
-}
-
-/**
- * Navigation Menu Walker — adds active classes.
- *
- * What: Renders menu items with an 'active' class for current + ancestor.
- * Who calls it: wp_nav_menu() in header.php with walker => new instance.
- * Dependencies: Walker_Nav_Menu.
- */
-class Peptide_Starter_Nav_Walker extends Walker_Nav_Menu {
-
-	/**
-	 * Render a single menu item.
-	 *
-	 * @param string   $output Item output accumulator.
-	 * @param WP_Post  $item   Menu item data.
-	 * @param int      $depth  Menu depth.
-	 * @param stdClass $args   Menu arguments.
-	 * @param int      $id     Current item ID.
-	 * @return void
-	 */
-	public function start_el( &$output, $item, $depth = 0, $args = null, $id = 0 ) {
-		$indent    = ( $depth ) ? str_repeat( "\t", $depth ) : '';
-		$classes   = empty( $item->classes ) ? array() : (array) $item->classes;
-		$classes[] = 'menu-item-' . $item->ID;
-
-		if ( in_array( 'current-menu-item', $classes, true ) || in_array( 'current-menu-parent', $classes, true ) ) {
-			$classes[] = 'active';
-		}
-
-		$args        = apply_filters( 'nav_menu_item_args', $args, $item, $depth );
-		$class_names = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args, $depth ) );
-		$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
-
-		$item_id = apply_filters( 'nav_menu_item_id', 'menu-item-' . $item->ID, $item, $args, $depth );
-		$item_id = $item_id ? ' id="' . esc_attr( $item_id ) . '"' : '';
-
-		$output .= $indent . '<li' . $item_id . $class_names . '>';
-
-		$atts = array(
-			'title'  => ! empty( $item->attr_title ) ? $item->attr_title : '',
-			'target' => ! empty( $item->target ) ? $item->target : '',
-			'rel'    => ! empty( $item->xfn ) ? $item->xfn : '',
-			'href'   => ! empty( $item->url ) ? $item->url : '',
-		);
-
-		$atts       = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args, $depth );
-		$attributes = '';
-
-		foreach ( $atts as $attr => $value ) {
-			if ( ! empty( $value ) ) {
-				$value       = ( 'href' === $attr ) ? esc_url( $value ) : esc_attr( $value );
-				$attributes .= ' ' . $attr . '="' . $value . '"';
-			}
-		}
-
-		$title = apply_filters( 'the_title', $item->title, $item->ID );
-
-		$link  = $args->before;
-		$link .= '<a' . $attributes . '>';
-		$link .= $args->link_before . $title . $args->link_after;
-		$link .= '</a>';
-		$link .= $args->after;
-
-		$output .= $link . "</li>\n";
-	}
-}
-
-/**
- * Fallback menu when no primary nav is assigned in WP admin.
- *
- * Previously lived inline inside header.php; moved here in v1.5.1 to
- * prevent redeclaration if header.php is ever included twice.
- *
- * @return void Echoes a complete <ul>.
- */
-function peptide_starter_primary_menu_fallback() {
-	?>
-	<ul>
-		<li><a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php esc_html_e( 'Home', 'peptide-starter' ); ?></a></li>
-		<li class="menu-item-has-children">
-			<a href="#"><?php esc_html_e( 'Tools', 'peptide-starter' ); ?></a>
-			<ul class="sub-menu">
-				<li><a href="<?php echo esc_url( home_url( '/calculator' ) ); ?>"><?php esc_html_e( 'Calculator', 'peptide-starter' ); ?></a></li>
-				<li><a href="<?php echo esc_url( home_url( '/protocol-builder' ) ); ?>"><?php esc_html_e( 'Protocol Builder', 'peptide-starter' ); ?></a></li>
-				<li><a href="<?php echo esc_url( home_url( '/tracker' ) ); ?>"><?php esc_html_e( 'Tracker', 'peptide-starter' ); ?></a></li>
-			</ul>
-		</li>
-		<li class="menu-item-has-children">
-			<a href="#"><?php esc_html_e( 'My Data', 'peptide-starter' ); ?></a>
-			<ul class="sub-menu">
-				<li><a href="<?php echo esc_url( home_url( '/peptides' ) ); ?>"><?php esc_html_e( 'Peptides', 'peptide-starter' ); ?></a></li>
-				<li><a href="<?php echo esc_url( home_url( '/subject-log' ) ); ?>"><?php esc_html_e( 'Subject Log', 'peptide-starter' ); ?></a></li>
-			</ul>
-		</li>
-		<li class="menu-item-has-children">
-			<a href="#"><?php esc_html_e( 'Resources', 'peptide-starter' ); ?></a>
-			<ul class="sub-menu">
-				<li><a href="<?php echo esc_url( home_url( '/documentation' ) ); ?>"><?php esc_html_e( 'Documentation', 'peptide-starter' ); ?></a></li>
-				<li><a href="<?php echo esc_url( home_url( '/news' ) ); ?>"><?php esc_html_e( 'Science Feed', 'peptide-starter' ); ?></a></li>
-			</ul>
-		</li>
-	</ul>
-	<?php
 }
 
 /**
@@ -182,7 +82,7 @@ function peptide_starter_get_search_placeholder() {
  * @return string Copyright text (may contain safe HTML).
  */
 function peptide_starter_get_footer_copyright() {
-	return get_theme_mod( 'footer_copyright', esc_html__( 'Copyright © 2026 Peptide Repo. All rights reserved.', 'peptide-starter' ) );
+	return get_theme_mod( 'footer_copyright', esc_html__( 'Copyright \u00a9 2026 Peptide Repo. All rights reserved.', 'peptide-starter' ) );
 }
 
 /**
@@ -217,8 +117,8 @@ function peptide_starter_pagination() {
 			'format'    => 'page/%#%/',
 			'current'   => $current,
 			'total'     => $total,
-			'prev_text' => esc_html__( '← Previous', 'peptide-starter' ),
-			'next_text' => esc_html__( 'Next →', 'peptide-starter' ),
+			'prev_text' => esc_html__( '\u2190 Previous', 'peptide-starter' ),
+			'next_text' => esc_html__( 'Next \u2192', 'peptide-starter' ),
 			'type'      => 'plain',
 		)
 	);
@@ -248,8 +148,8 @@ function peptide_starter_safe_referer() {
 /**
  * Gate a template behind login + verified email.
  *
- * Unauthenticated → redirect to /auth?redirect_to=current-uri.
- * Logged in but unverified → redirect to /profile?verify_required=1.
+ * Unauthenticated \u2192 redirect to /auth?redirect_to=current-uri.
+ * Logged in but unverified \u2192 redirect to /profile?verify_required=1.
  *
  * Side effects: emits 302 and exits the request.
  *

--- a/inc/nav-walker.php
+++ b/inc/nav-walker.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Navigation Menu Walker & Primary Menu Fallback
+ *
+ * What: Custom nav walker that adds 'active' CSS classes, plus a fallback
+ *       menu rendered when no primary nav is assigned in WP admin.
+ * Who calls it: header.php — wp_nav_menu() with walker => new Peptide_Starter_Nav_Walker(),
+ *               and the callback_function parameter for the fallback.
+ * Dependencies: Walker_Nav_Menu (WordPress core).
+ *
+ * Extracted from inc/helpers.php in v2.3.0 to keep both files under 300 lines.
+ *
+ * @package peptide-starter
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Navigation Menu Walker — adds active classes.
+ *
+ * What: Renders menu items with an 'active' class for current + ancestor items.
+ * Who calls it: wp_nav_menu() in header.php with walker => new instance.
+ * Dependencies: Walker_Nav_Menu.
+ */
+class Peptide_Starter_Nav_Walker extends Walker_Nav_Menu {
+
+	/**
+	 * Render a single menu item.
+	 *
+	 * @param string   $output Item output accumulator (passed by reference).
+	 * @param WP_Post  $item   Menu item data.
+	 * @param int      $depth  Menu depth.
+	 * @param stdClass $args   Menu arguments.
+	 * @param int      $id     Current item ID.
+	 * @return void
+	 */
+	public function start_el( &$output, $item, $depth = 0, $args = null, $id = 0 ) {
+		$indent    = ( $depth ) ? str_repeat( "\t", $depth ) : '';
+		$classes   = empty( $item->classes ) ? array() : (array) $item->classes;
+		$classes[] = 'menu-item-' . $item->ID;
+
+		if ( in_array( 'current-menu-item', $classes, true ) || in_array( 'current-menu-parent', $classes, true ) ) {
+			$classes[] = 'active';
+		}
+
+		$args        = apply_filters( 'nav_menu_item_args', $args, $item, $depth );
+		$class_names = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args, $depth ) );
+		$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
+
+		$item_id = apply_filters( 'nav_menu_item_id', 'menu-item-' . $item->ID, $item, $args, $depth );
+		$item_id = $item_id ? ' id="' . esc_attr( $item_id ) . '"' : '';
+
+		$output .= $indent . '<li' . $item_id . $class_names . '>';
+
+		$atts = array(
+			'title'  => ! empty( $item->attr_title ) ? $item->attr_title : '',
+			'target' => ! empty( $item->target ) ? $item->target : '',
+			'rel'    => ! empty( $item->xfn ) ? $item->xfn : '',
+			'href'   => ! empty( $item->url ) ? $item->url : '',
+		);
+
+		$atts       = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args, $depth );
+		$attributes = '';
+
+		foreach ( $atts as $attr => $value ) {
+			if ( ! empty( $value ) ) {
+				$value       = ( 'href' === $attr ) ? esc_url( $value ) : esc_attr( $value );
+				$attributes .= ' ' . $attr . '="' . $value . '"';
+			}
+		}
+
+		$title = apply_filters( 'the_title', $item->title, $item->ID );
+
+		$link  = $args->before;
+		$link .= '<a' . $attributes . '>';
+		$link .= $args->link_before . $title . $args->link_after;
+		$link .= '</a>';
+		$link .= $args->after;
+
+		$output .= $link . "</li>\n";
+	}
+}
+
+/**
+ * Fallback menu when no primary nav is assigned in WP admin.
+ *
+ * Previously lived inline inside header.php; moved to inc/helpers.php in
+ * v1.5.1 to prevent redeclaration, then extracted here in v2.3.0.
+ *
+ * @return void Echoes a complete <ul>.
+ */
+function peptide_starter_primary_menu_fallback() {
+	?>
+	<ul>
+		<li><a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php esc_html_e( 'Home', 'peptide-starter' ); ?></a></li>
+		<li class="menu-item-has-children">
+			<a href="#"><?php esc_html_e( 'Tools', 'peptide-starter' ); ?></a>
+			<ul class="sub-menu">
+				<li><a href="<?php echo esc_url( home_url( '/calculator' ) ); ?>"><?php esc_html_e( 'Calculator', 'peptide-starter' ); ?></a></li>
+				<li><a href="<?php echo esc_url( home_url( '/protocol-builder' ) ); ?>"><?php esc_html_e( 'Protocol Builder', 'peptide-starter' ); ?></a></li>
+				<li><a href="<?php echo esc_url( home_url( '/tracker' ) ); ?>"><?php esc_html_e( 'Tracker', 'peptide-starter' ); ?></a></li>
+			</ul>
+		</li>
+		<li class="menu-item-has-children">
+			<a href="#"><?php esc_html_e( 'My Data', 'peptide-starter' ); ?></a>
+			<ul class="sub-menu">
+				<li><a href="<?php echo esc_url( home_url( '/peptides' ) ); ?>"><?php esc_html_e( 'Peptides', 'peptide-starter' ); ?></a></li>
+				<li><a href="<?php echo esc_url( home_url( '/subject-log' ) ); ?>"><?php esc_html_e( 'Subject Log', 'peptide-starter' ); ?></a></li>
+			</ul>
+		</li>
+		<li class="menu-item-has-children">
+			<a href="#"><?php esc_html_e( 'Resources', 'peptide-starter' ); ?></a>
+			<ul class="sub-menu">
+				<li><a href="<?php echo esc_url( home_url( '/documentation' ) ); ?>"><?php esc_html_e( 'Documentation', 'peptide-starter' ); ?></a></li>
+				<li><a href="<?php echo esc_url( home_url( '/news' ) ); ?>"><?php esc_html_e( 'Science Feed', 'peptide-starter' ); ?></a></li>
+			</ul>
+		</li>
+	</ul>
+	<?php
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "peptide-starter-theme",
+  "version": "2.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "peptide-starter-theme",
+      "version": "2.3.0",
+      "license": "GPL-2.0-or-later"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "peptide-starter-theme",
+  "version": "2.3.0",
+  "description": "WordPress theme for peptiderepo.com",
+  "private": true,
+  "scripts": {
+    "lint": "find assets/js -name '*.js' -print0 | xargs -0 -I{} node --check {}"
+  },
+  "license": "GPL-2.0-or-later"
+}

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/peptiderepo/peptide-starter
 Description: Premium, accessible WordPress theme for scientific peptide reference database
 Author: Peptide Repo
 Author URI: https://peptiderepo.com
-Version: 2.2.2
+Version: 2.3.0
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: peptide-starter


### PR DESCRIPTION
## What changed

Adopts the peptiderepo estate CI standard (wave 2) on `peptide-starter-theme`.

### CI workflow (`.github/workflows/ci.yml`)
- Replaced the 3-job per-repo CI (php-lint matrix, phpcs `continue-on-error`, phpunit matrix) with a **thin caller** delegating to `peptiderepo/peptide-e2e/.github/workflows/ci.yml@main`.
- Inputs: `tests: wp-framework`, `has_js: true`, `line_limit_paths: inc`.
- Added `workflow_call` trigger (required for deploy.yml gating).
- Added workflow-level `permissions: contents: write` (required for phpcbf auto-fix commit-back).

### Deploy workflow (`.github/workflows/deploy.yml`)
- Retired the standalone `validate` job (PHP lint + PHPCS + JS check) — the reusable CI covers all of those.
- Deploy now gates on `uses: ./.github/workflows/ci.yml` (valid via `workflow_call`).
- Shared `deploy-app.yml` caller and staging step remain intact.

### composer.json
- `test` script: `phpunit` → `vendor/bin/phpunit` (explicit path; reusable calls `composer test`).

### 300-line split: `inc/helpers.php` (311→211 lines)
- `Peptide_Starter_Nav_Walker` class and `peptide_starter_primary_menu_fallback()` extracted to new **`inc/nav-walker.php`** (123 lines).
- `functions.php` updated to `require_once` nav-walker.php before helpers.php.

### npm manifest (`package.json` + `package-lock.json`)
- Minimal manifest added (no runtime deps) so the reusable `lint-js` job can run `npm ci`.
- `npm run lint` runs `node --check` on all `assets/js/*.js` files.

### Version bump
- `PEPTIDE_STARTER_VERSION` constant: `2.2.2` → `2.3.0`
- `style.css` `Version:` header: `2.2.2` → `2.3.0`
- CHANGELOG updated.

## Why
CI standardization wave 2 per [recipe in seq 07](../convo/engineer-infra/threads/2026-06-cicd-rollout/07-cto-recipe-wave2.md).

## Risk flags
- The old `phpcs` job had `continue-on-error: true` (non-blocking). The reusable PHPCS job is **strict** — phpcbf will auto-fix on the PR branch, then fail on any remaining non-auto-fixable violations. Expect the first CI run to either auto-fix+pass or flag real violations.
- `inc/helpers.php` split is a refactor: nav walker class and fallback function moved to a new file, included first. PHP is stateless at include-time so load order doesn't affect runtime behaviour. The class is instantiated by header.php, not by the include chain.

## wp-framework PHPUnit compatibility
The theme already ships `bin/install-wp-tests.sh`, `tests/bootstrap.php`, and `phpunit.xml` — the exact artifacts the reusable wp-framework job expects. All three gotchas (svn install, skip-db-create, trailing slash on WP_CORE_DIR) are handled in the reusable. The bootstrap sets `WP_TESTS_DIR=/tmp/wordpress-tests-lib` via env, matching the reusable's export. Compatible.

## Test plan
1. CI runs on this PR — expect phpcbf pass → strict PHPCS pass → wp-framework PHPUnit green → file-size pass → lint-js pass.
2. Do NOT merge — CTO reviews CI results, then merges + deploys.