### PR TITLE
ci: add permissions: write + secrets:inherit to deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 concurrency:
   group: deploy-peptide-starter-theme
   cancel-in-progress: true
@@ -15,6 +18,7 @@ jobs:
   # "ci / ci (lint-php (8.1))" etc.
   ci:
     uses: ./.github/workflows/ci.yml
+    secrets: inherit
 
   deploy:
     name: Deploy (shared pipeline)


### PR DESCRIPTION
## What changed
Added `permissions: contents: write` to `deploy.yml` workflow level and `secrets: inherit` to the `ci:` job.

## Why
Without a `permissions:` block, GitHub defaults to read-only for public repos. The nested reusable `ci.yml` requires `contents: write` (for phpcbf auto-commit). This mismatch causes `startup_failure` on all deploys since PR #21 switched the deploy runner to `peptide-vps`.

## Risk flags
Low. Workflow metadata only.

## Test plan
Deploy should now start without startup_failure.